### PR TITLE
Replace unique identifier check and prep for NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,41 @@
 Ensure your system has `git`, `jq`. `lscpu`, `lshw` and `ansible-playbook` packages available to your user.
 
 Pull the Orchestration File & example vars file
-```
+```bash
 curl https://raw.githubusercontent.com/systeminit/si-device-compliance/main/orchestrate-install.sh > /tmp/orchestrate-install.sh
 curl https://raw.githubusercontent.com/systeminit/si-device-compliance/main/installation.vars.example > /tmp/installation.vars
 ```
 
 Make the script executable
-```
+```bash
 chmod a+x /tmp/orchestrate-install.sh 
 ```
 
 Adjust the variables file for your user/machine values
-```
+```bash
+# Use your editor of choice
 vim /tmp/installation.vars
 ```
+
 Modify these fields to their correct value:
-```
+```bash
 EMAIL_ADDRESS: [email_id]                     # Your corporate systeminit.com email id
-SUBMISSION_TOKEN: [submission_token]          # Your submission token # Appendix 2 - Generating a Submission Token
+SUBMISSION_TOKEN: [submission_token]          # Your submission token (or path to a single-line file containing it) # Appendix 2 - Generating a Submission Token
 ROOT_DISK_ENCRYPTED_PARTITION_BLK: [disk-id]  # Your encrypted OS root disk blk
 USING_PASSWORD_MANAGER: [true/false]          # Whether you are using a password manager
 ```
 
 Run the installation:
-```
+```bash
 /bin/bash /tmp/orchestrate-install.sh /tmp/installation.vars
+
+# You may need to use bash from your PATH
+bash /tmp/orchestrate-install.sh /tmp/installation.vars
 ```
 
 You can check it is submitting correctly with:
-```
-sudo /etc/si-device-compliance/collect_compliance_data.sh <your token>
+```bash
+sudo /etc/si-device-compliance/collect_compliance_data.sh <YOUR-TOKEN-OR-PATH>
 ```
 
 ## System Initiative Device Compliance Background

--- a/compliance/ansible/main.yaml
+++ b/compliance/ansible/main.yaml
@@ -27,6 +27,7 @@
     - name: Install Antivirus / Verify Installation
       ansible.builtin.include_role:
         name: antivirus
+      when: INSTALL_ANTIVIRUS
 
     - name: Install Service and Timer to submit evidence
       ansible.builtin.include_role:

--- a/compliance/ansible/roles/service/tasks/main.yaml
+++ b/compliance/ansible/roles/service/tasks/main.yaml
@@ -18,7 +18,7 @@
     group: root
     mode: '0755'
     content: |
-      #!/bin/bash
+      #!/usr/bin/env bash
 
       set -eo pipefail 
       
@@ -28,6 +28,11 @@
       SCRIPT_VERSION="{{ SCRIPT_VERSION }}"
       SCRIPT_USER="{{ EMAIL_ADDRESS }}"
       SUBMISSION_TOKEN="${1:-unset}"
+
+      # If the variable corresponds to a file path, read the token from the file provided.
+      if [ -f "$SUBMISSION_TOKEN" ]; then
+        SUBMISSION_TOKEN="$(cat "$SUBMISSION_TOKEN")"
+      fi
 
       echo "----------------------------------------------------"
 
@@ -43,12 +48,16 @@
       ] | join(", ")')"
       echo "LSCPU found to be $LSCPU"
 
-      # Looking output like: 230318033800674 - Pro WS WRX80E-SAGE SE WIFI
-      LSHW="$(lshw -json | jq -r '
+      # Looking output like: 1783e116-bf08-36b8-b28e-08bfb836b28d
+      HARDWARE_UUID="$(dmidecode --type system | grep UUID | awk -F: '{ print $2 }' | tr -d '[:space:]')"
+      echo "HARDWARE_UUID found to be $HARDWARE_UUID"
+
+      # Looking output like: 1783e116-bf08-36b8-b28e-08bfb836b28d - Pro WS WRX80E-SAGE SE WIFI
+      LSHW="$(lshw -json | jq -r "
         .children[] 
-        | select(.description == "Motherboard") 
-        | "\(.serial) - \(.product)"
-      ')"
+        | select(.description == \"Motherboard\") 
+        | \"${HARDWARE_UUID} - \(.product)\"
+      ")"
       echo "LSHW found to be $LSHW"
 
       SERIAL_NUMBER="$(lshw -json | jq -r '
@@ -57,10 +66,6 @@
         | "\(.serial)"
       ')"
       echo "SERIAL_NUMBER found to be $SERIAL_NUMBER"
-
-      # Looking output like: 1783e116-bf08-36b8-b28e-08bfb836b28d
-      HARDWARE_UUID="$(dmidecode --type system | grep UUID | awk -F: '{ print $2 }')"
-      echo "HARDWARE_UUID found to be $HARDWARE_UUID"
 
       # Looking output like: 
       DISKS="$(lsblk -J | jq '{
@@ -161,6 +166,7 @@
         --data-raw "$RESOURCES"
 
 - name: Set up systemd timer for compliance data collection
+  when: INSTALL_SYSTEMD_SERVICE
   block:
     - name: Create systemd service file for compliance data collection
       copy:

--- a/examples/si-nixos-configuration.nix
+++ b/examples/si-nixos-configuration.nix
@@ -1,0 +1,72 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  # ========== INSTRUCTIONS ==========
+  # 1) follow the README instructions until you edit the "installation.vars" file
+  # 2) prepare your compliance token for the next step (i.e. have it handy!)
+  # 3) run the following command: "sudo mkdir -p /etc/si-device-compliance"
+  # 4) run the following command (and replace the relevant token piece): "echo <YOUR-TOKEN-HERE> | sudo tee /etc/si-device-compliance/token.txt"
+  # 5) follow NixOS-relevant instructions in the "installation.vars" file
+  # 6) in that file, set the "SUBMISSION_TOKEN" to "/etc/si-device-compliance/token.txt"
+  # 7) import THIS file into your NixOS configuration using "imports = [./path/to/si-nixos-configuration.nix];"
+  # 8) rebuild your NixOS configuration
+  # 9) continue following the README instructions
+  # ==================================
+
+  # Install base packages needed for installation and data collection
+  environment.systemPackages = with pkgs; [
+    ansible
+    bash
+    curl
+    dmidecode
+    git
+    jq
+    lshw
+  ];
+
+  # Install and setup the antivirus
+  services.clamav.daemon.enable = true;
+  services.clamav.scanner.enable = true;
+  services.clamav.updater.enable = true;
+
+  # Install and setup compliance data collection
+  systemd.services."collect_compliance_data" = {
+    enable = true;
+    description = "Collect Compliance Data";
+    unitConfig = {
+      Type = "simple";
+    };
+    serviceConfig = {
+      Type = "oneshot";
+      User = "root";
+      ExecStart = "/etc/si-device-compliance/collect_compliance_data.sh /etc/si-device-compliance/token.txt";
+      StandardOutput = append:/etc/si-device-compliance/logs/run.log;
+      StandardError = append:/etc/si-device-compliance/logs/run.log;
+    };
+  };
+
+  # Run compliance data collection on boot
+  systemd.timers."collect_compliance_data" = {
+    enable = true;
+    description = "Timer to run compliance data collection 10 minutes after boot";
+    timerConfig = {
+      OnBootSec = "10min";
+      Unit = "collect_compliance_data.service";
+    };
+    wantedBy = ["timers.target"];
+  };
+
+  # Run compliance data collection monthly
+  systemd.timers."collect_compliance_data_monthly" = {
+    enable = true;
+    description = "Timer to run compliance data collection every month";
+    timerConfig = {
+      OnCalendar = "monthly";
+      Unit = "collect_compliance_data.service";
+    };
+    wantedBy = ["timers.target"];
+  };
+}

--- a/installation.vars.example
+++ b/installation.vars.example
@@ -12,9 +12,24 @@ RESULTS_DIR: /etc/si-device-compliance/results
 LOGS_DIR: /etc/si-device-compliance/logs
 SERVICE_SCRIPT_PATH: /etc/si-device-compliance/collect_compliance_data.sh
 
+# If you are running a distribution without a solid means of imperative package installation,
+# (e.g. NixOS), then you can opt-out of installing the AV. However, you are responsible for
+# installing it correctly. To do so, set the value to "false".
+INSTALL_ANTIVIRUS: true
+
+# If you are running a distribution that disallows imperative systemd service installation, # (e.g.
+# NixOS), then you can opt-out of installing service. However, you are responsible for installing
+# it correctly, meaning that the compliance script runs on a monthly cadence. To do so, set the
+# value to "false".
+INSTALL_SYSTEMD_SERVICE: true
+
 # -----------------------------------------
 # Compliance Tracking Variables
 EMAIL_ADDRESS: [email_id]
+
+# This can either be the literal token or a path to a single-line file containing the token. This
+# is particularly helpful if you are checking in configuration files or unit files into source
+# control (e.g NixOS). Example location if using a file: "/etc/si-device-compliance/token.txt".
 SUBMISSION_TOKEN: [submission_token]
 
 # The root disk of your machine must be encrypted, enter the blk reference to

--- a/orchestrate-install.sh
+++ b/orchestrate-install.sh
@@ -1,9 +1,14 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 # Call this function with: 
 # ./orchestrate-install.sh <filepath to variables>
 
 set -eo pipefail
+
+if [ "$EUID" -eq 0 ]; then
+	echo "error: must not run directly as root"
+	exit 1
+fi
+sudo -v
 
 VARIABLES_FILE="${1:-/tmp/installation.vars}"
 


### PR DESCRIPTION
Primary:
- Use "/usr/bin/env bash" for script invocations
- Perform "sudo -v" and user check in orchestration script
- Account for pitfalls in PATH in README
- Add bash syntax highlighting in README

NixOS:
- Add ability to specify token file path instead of a raw token string
- Add AV install opt-out option (you still need it!)
- Allow opt-out systemd service install (you still need it!)
- Add NixOS configuration file example
