### PR TITLE
Fix service and special case NixOS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The system configuration is written in such a way that the following (or any oth
 
 Any questions with any of this, please reach out to [technical-operations@systeminit.com](mailto:technical-operations@systeminit.com) or reach out in Slack to john@systeminit.com.
 
+### Special Cases
+
+Documented special case instructions and code are location in the [special-cases](special-cases) directory (e.g. NixOS).
+
 <br/>
 
 ## What is in this repository?

--- a/special-cases/NIXOS.md
+++ b/special-cases/NIXOS.md
@@ -1,0 +1,30 @@
+# Special Cases: NixOS
+
+This document covers compliance for a special case distribution: NixOS.
+The contents of this document are intentionally high level to prevent drift.
+
+## Onboarding Guide
+
+1. Follow the guide in the [README](../README.md) until the step involving editing the installation variables
+1. Perform the compliance token step and have your compliance token handy
+1. Run the following command: `sudo mkdir -p /etc/si-device-compliance`
+1. Replace the `<YOUR-TOKEN-HERE>` argument with your token in the _next_ step
+1. Run the following command: `echo <YOUR-TOKEN-HERE> | sudo tee /etc/si-device-compliance/token.txt`
+1. Edit the installation variables file and follow all NixOS-relevant tips in the file (e.g. using the token file path)
+
+Now that we have perform the initial setup steps, we can extend our NixOS configuration.
+Add the following to your NixOS configuration (e.g. `configuration.nix`):
+
+```nix
+imports = [
+  (import (builtins.fetchurl {
+    url = "https://raw.githubusercontent.com/systeminit/si-device-compliance/refs/heads/main/special-cases/compliance/si-nixos-configuration.nix";
+    sha256 = lib.fakeSha256;
+  }))
+];
+```
+
+After that, reload your NixOS configuration, add the correct `sha256` (you'll be told what it is), and reload again.
+You may need to reboot your system after this dance.
+
+**You can now return to the guide in the [README](../README.md)!**

--- a/special-cases/compliance/si-nixos-configuration.nix
+++ b/special-cases/compliance/si-nixos-configuration.nix
@@ -4,18 +4,6 @@
   pkgs,
   ...
 }: {
-  # ========== INSTRUCTIONS ==========
-  # 1) follow the README instructions until you edit the "installation.vars" file
-  # 2) prepare your compliance token for the next step (i.e. have it handy!)
-  # 3) run the following command: "sudo mkdir -p /etc/si-device-compliance"
-  # 4) run the following command (and replace the relevant token piece): "echo <YOUR-TOKEN-HERE> | sudo tee /etc/si-device-compliance/token.txt"
-  # 5) follow NixOS-relevant instructions in the "installation.vars" file
-  # 6) in that file, set the "SUBMISSION_TOKEN" to "/etc/si-device-compliance/token.txt"
-  # 7) import THIS file into your NixOS configuration using "imports = [./path/to/si-nixos-configuration.nix];"
-  # 8) rebuild your NixOS configuration
-  # 9) continue following the README instructions
-  # ==================================
-
   # Install base packages needed for installation and data collection
   environment.systemPackages = with pkgs; [
     ansible
@@ -36,9 +24,6 @@
   systemd.services."collect_compliance_data" = {
     enable = true;
     description = "Collect Compliance Data";
-    unitConfig = {
-      Type = "simple";
-    };
     serviceConfig = {
       Type = "oneshot";
       User = "root";


### PR DESCRIPTION
- Fix the compliance collection service for NixOS by removing the "Type" field in the "[Unit]" section
- Add special case instructions for NixOS that should be fairly resistant to drift over time
- Move configuration file for NixOS into the new special case directory
- Call out the special cases directory in the README